### PR TITLE
"25-03-07 김남규 | 당화공정 CSS 제외 모두 구현"

### DIFF
--- a/src/apis/production-process/mashing-process/MashingProcessApi.js
+++ b/src/apis/production-process/mashing-process/MashingProcessApi.js
@@ -3,10 +3,10 @@ import axios from 'axios';
 const BASE_URL = 'http://localhost:8080/mashingprocess';
 
 const mashingProcessApi = {
-    // 당화 데이터 저장 (CREATE)
-    saveMashingData: async (data) => {
+    // 📌 당화 데이터 저장 (CREATE)
+    saveMashingData: async (mashingRequestData) => {
         try {
-            const response = await axios.post(`${BASE_URL}/register`, data, {
+            const response = await axios.post(`${BASE_URL}/register`, mashingRequestData, {
                 headers: { "Content-Type": "application/json" }
             });
             return response.data;
@@ -17,9 +17,9 @@ const mashingProcessApi = {
     },
 
     // 📌 특정 LOT_NO에 대한 분쇄공정 상태 업데이트
-    updateMashingStatus: async (lotNo, statusData) => {
+    updateMashingStatus: async (lotNo, mashingStatusUpdate) => {
         try {
-            const response = await axios.put(`${BASE_URL}/update`, statusData, {
+            const response = await axios.put(`${BASE_URL}/update`, mashingStatusUpdate, {
                 headers: { "Content-Type": "application/json" }
             });
             return response.data;
@@ -30,9 +30,9 @@ const mashingProcessApi = {
     },
 
     // 📌 당화공정 pH 값 및 실제 종료시간 업데이트
-    updateMashingProcess: async (mashingId, updateData) => {
+    updateMashingProcess: async (mashingId, mashingUpdatePayload) => {
         try {
-            const response = await axios.put(`${BASE_URL}/register/${mashingId}`, updateData, {
+            const response = await axios.put(`${BASE_URL}/register/${mashingId}`, mashingUpdatePayload, {
                 headers: { "Content-Type": "application/json" }
             });
             return response.data;
@@ -46,18 +46,23 @@ const mashingProcessApi = {
     getMaterialsByLotNo: async (lotNo) => {
         try {
             const response = await axios.get(`${BASE_URL}/${lotNo}`);
-            return response.data;
+            console.log("📌 자재 목록 응답:", response.data); // 디버깅
+    
+            // ✅ `result.materials`만 반환하도록 수정
+            return response.data.result?.materials || []; 
         } catch (error) {
             console.error(`❌ 자재 정보 조회 실패 (LOT_NO: ${lotNo}):`, error);
-            throw error;
+            return [];
         }
     },
-
+    
     // 📌 작업지시 ID 목록 조회
     getWorkOrderList: async () => {
         try {
             const response = await axios.get(`${BASE_URL}/linematerial`);
-            return response.data;
+            
+            const workOrderList = response.data;
+            return workOrderList;
         } catch (error) {
             console.error("❌ 작업지시 ID 목록 조회 실패:", error);
             throw error;

--- a/src/apis/production-process/mashing-process/MashingProcessApi.js
+++ b/src/apis/production-process/mashing-process/MashingProcessApi.js
@@ -1,73 +1,110 @@
-import axios from 'axios';
+import axios from "axios";
 
-const BASE_URL = 'http://localhost:8080/mashingprocess';
+const BASE_URL = "http://localhost:8080/mashingprocess";
 
 const mashingProcessApi = {
-    // 📌 당화 데이터 저장 (CREATE)
-    saveMashingData: async (mashingRequestData) => {
-        try {
-            const response = await axios.post(`${BASE_URL}/register`, mashingRequestData, {
-                headers: { "Content-Type": "application/json" }
-            });
-            return response.data;
-        } catch (error) {
-            console.error("❌ 당화 데이터 저장 실패:", error);
-            throw error;
+  // 📌 당화 데이터 저장 (CREATE)
+  saveMashingData: async (mashingRequestData) => {
+    try {
+      const response = await axios.post(
+        `${BASE_URL}/register`,
+        mashingRequestData,
+        {
+          headers: { "Content-Type": "application/json" },
         }
-    },
-
-    // 📌 특정 LOT_NO에 대한 분쇄공정 상태 업데이트
-    updateMashingStatus: async (lotNo, mashingStatusUpdate) => {
-        try {
-            const response = await axios.put(`${BASE_URL}/update`, mashingStatusUpdate, {
-                headers: { "Content-Type": "application/json" }
-            });
-            return response.data;
-        } catch (error) {
-            console.error(`❌ 분쇄공정 상태 업데이트 실패 (LOT_NO: ${lotNo}):`, error);
-            throw error;
-        }
-    },
-
-    // 📌 당화공정 pH 값 및 실제 종료시간 업데이트
-    updateMashingProcess: async (mashingId, mashingUpdatePayload) => {
-        try {
-            const response = await axios.put(`${BASE_URL}/register/${mashingId}`, mashingUpdatePayload, {
-                headers: { "Content-Type": "application/json" }
-            });
-            return response.data;
-        } catch (error) {
-            console.error(`❌ 당화공정 업데이트 실패 (MashingID: ${mashingId}):`, error);
-            throw error;
-        }
-    },
-
-    // 📌 특정 LOT_NO에 대한 자재 정보 조회
-    getMaterialsByLotNo: async (lotNo) => {
-        try {
-            const response = await axios.get(`${BASE_URL}/${lotNo}`);
-            console.log("📌 자재 목록 응답:", response.data); // 디버깅
-    
-            // ✅ `result.materials`만 반환하도록 수정
-            return response.data.result?.materials || []; 
-        } catch (error) {
-            console.error(`❌ 자재 정보 조회 실패 (LOT_NO: ${lotNo}):`, error);
-            return [];
-        }
-    },
-    
-    // 📌 작업지시 ID 목록 조회
-    getWorkOrderList: async () => {
-        try {
-            const response = await axios.get(`${BASE_URL}/linematerial`);
-            
-            const workOrderList = response.data;
-            return workOrderList;
-        } catch (error) {
-            console.error("❌ 작업지시 ID 목록 조회 실패:", error);
-            throw error;
-        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("❌ 당화 데이터 저장 실패:", error);
+      throw error;
     }
+  },
+
+  // 📌 특정 LOT_NO에 대한 분쇄공정 상태 업데이트
+  updateMashingStatus: async (lotNo, mashingStatusUpdate) => {
+    try {
+      const response = await axios.put(
+        `${BASE_URL}/update`,
+        mashingStatusUpdate,
+        {
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error(
+        `❌ 분쇄공정 상태 업데이트 실패 (LOT_NO: ${lotNo}):`,
+        error
+      );
+      throw error;
+    }
+  },
+
+
+  
+ // 📌 당화공정 pH 값 및 실제 종료시간 업데이트
+updateMashingProcess: async (mashingId, mashingUpdatePayload) => {
+  if (!mashingId) {
+    console.error("❌ updateMashingProcess 요청 실패: mashingId가 없습니다.");
+    throw new Error("Mashing ID is required");
+  }
+
+  try {
+    console.log(`📌 API 요청: PUT /mashingprocess/update/${mashingId}`, mashingUpdatePayload);
+
+    const response = await axios.put(
+      `${BASE_URL}/update/${mashingId}`,
+      {
+        phValue: mashingUpdatePayload.phValue || null, 
+        actualEndTime: mashingUpdatePayload.actualEndTime || new Date().toISOString(),
+      },
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    console.log("✅ 당화공정 업데이트 성공:", response.data);
+    return response.data;
+  } catch (error) {
+    if (error.response) {
+      console.error(
+        `❌ 당화공정 업데이트 실패 (MashingID: ${mashingId}):`,
+        error.response.data
+      );
+    } else {
+      console.error(`❌ 당화공정 업데이트 실패 (MashingID: ${mashingId}):`, error);
+    }
+    throw error;
+  }
+},
+
+
+  // 📌 특정 LOT_NO에 대한 자재 정보 조회
+  getMaterialsByLotNo: async (lotNo) => {
+    try {
+      const response = await axios.get(`${BASE_URL}/${lotNo}`);
+      console.log("📌 자재 목록 응답:", response.data); // 디버깅
+
+      // ✅ `result.materials`만 반환하도록 수정
+      return response.data.result?.materials || [];
+    } catch (error) {
+      console.error(`❌ 자재 정보 조회 실패 (LOT_NO: ${lotNo}):`, error);
+      return [];
+    }
+  },
+
+  // 📌 작업지시 ID 목록 조회
+  getWorkOrderList: async () => {
+    try {
+      const response = await axios.get(`${BASE_URL}/linematerial`);
+
+      const workOrderList = response.data;
+      return workOrderList;
+    } catch (error) {
+      console.error("❌ 작업지시 ID 목록 조회 실패:", error);
+      throw error;
+    }
+  },
 };
 
 export default mashingProcessApi;

--- a/src/components/production-process/mashing-process/MashingProcessControls.js
+++ b/src/components/production-process/mashing-process/MashingProcessControls.js
@@ -9,7 +9,6 @@ import CompleteModal from "../../standard-information/common/CompleteModal";
 import styles from "../../../styles/production-process/MashingProcessControls.module.css";
 
 const MashingProcessControls = ({ workOrder }) => {
-  const { mashingId } = useParams(); // URL에서 ID 가져오기
   const [mashingData, setMashingData] = useState({
     lotNo: workOrder?.lotNo || "", // 작업지시 ID 자동 불러오기
     mashingTime: "50",
@@ -18,9 +17,9 @@ const MashingProcessControls = ({ workOrder }) => {
     grainRatio: "",
     waterRatio: "",
     waterInputVolume: "",
-    processStatus: "대기 중",  
-    statusCode: "SC002",  
-    processName: "당화", 
+    processStatus: "진행 중",
+    statusCode: "SC002",
+    processName: "당화",
     notes: "",
   });
 
@@ -30,50 +29,51 @@ const MashingProcessControls = ({ workOrder }) => {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [showCompleteModal, setShowCompleteModal] = useState(false);
+  const [mashingId, setMashingId] = useState(null);
   const [buttonLabel, setButtonLabel] = useState("등록하기");
   const navigate = useNavigate(); // ✅ 페이지 이동을 위한 함수!
 
-    // ✅ workOrder가 변경될 때 lotNo를 업데이트
-    useEffect(() => {
-      if (workOrder?.lotNo) {
-        setMashingData((prev) => ({ ...prev, lotNo: workOrder.lotNo }));
-      }
-    }, [workOrder]);
-  
-    
-    // ✅ LOT_NO가 변경될 때 API 호출하여 "물" 데이터 가져오기
-    useEffect(() => {
-      if (!mashingData.lotNo) return; // ✅ LOT_NO가 없으면 실행하지 않음
-  
-      const fetchWaterInputVolume = async () => {
-        try {
-          console.log(`📌 LOT_NO=${mashingData.lotNo}의 자재 목록 조회 요청`);
-  
-          const materialsList = await mashingProcessApi.getMaterialsByLotNo(mashingData.lotNo);
-  
-          console.log("✅ 자재 목록:", materialsList);
-  
-          const waterMaterial = materialsList.find((item) => item.materialName === "물");
-  
-          if (waterMaterial) {
-            console.log(`🔍 물 데이터 찾음: ${waterMaterial.totalQty} L`);
-            setMashingData((prev) => ({
-              ...prev,
-              waterInputVolume: waterMaterial.totalQty, // ✅ 물 투입량 설정
-            }));
-          } else {
-            console.warn("⚠️ 물 데이터가 없음");
-          }
-        } catch (error) {
-          console.error("❌ 물 투입량 데이터를 가져오는 데 실패했습니다.", error);
+  // ✅ workOrder가 변경될 때 lotNo를 업데이트
+  useEffect(() => {
+    if (workOrder?.lotNo) {
+      setMashingData((prev) => ({ ...prev, lotNo: workOrder.lotNo }));
+    }
+  }, [workOrder]);
+
+  // ✅ LOT_NO가 변경될 때 API 호출하여 "물" 데이터 가져오기
+  useEffect(() => {
+    if (!mashingData.lotNo) return; // ✅ LOT_NO가 없으면 실행하지 않음
+
+    const fetchWaterInputVolume = async () => {
+      try {
+        console.log(`📌 LOT_NO=${mashingData.lotNo}의 자재 목록 조회 요청`);
+
+        const materialsList = await mashingProcessApi.getMaterialsByLotNo(
+          mashingData.lotNo
+        );
+
+        console.log("✅ 자재 목록:", materialsList);
+
+        const waterMaterial = materialsList.find(
+          (item) => item.materialName === "물"
+        );
+
+        if (waterMaterial) {
+          console.log(`🔍 물 데이터 찾음: ${waterMaterial.totalQty} L`);
+          setMashingData((prev) => ({
+            ...prev,
+            waterInputVolume: waterMaterial.totalQty, // ✅ 물 투입량 설정
+          }));
+        } else {
+          console.warn("⚠️ 물 데이터가 없음");
         }
-      };
-  
-      fetchWaterInputVolume();
-    }, [mashingData.lotNo]);
+      } catch (error) {
+        console.error("❌ 물 투입량 데이터를 가져오는 데 실패했습니다.", error);
+      }
+    };
 
-
-
+    fetchWaterInputVolume();
+  }, [mashingData.lotNo]);
 
   useEffect(() => {
     const savedLotNo = localStorage.getItem("selectedLotNo");
@@ -81,7 +81,6 @@ const MashingProcessControls = ({ workOrder }) => {
       setMashingData((prev) => ({ ...prev, lotNo: savedLotNo }));
     }
   }, []);
-
 
   // ✅ LOT_NO가 변경될 때 API 호출하여 자재 목록 조회 & 물 데이터 설정
   useEffect(() => {
@@ -91,30 +90,41 @@ const MashingProcessControls = ({ workOrder }) => {
       try {
         console.log(`📌 LOT_NO=${mashingData.lotNo}의 자재 목록 조회 요청`);
 
-        const materialsList = await mashingProcessApi.getMaterialsByLotNo(mashingData.lotNo);
+        const materialsList = await mashingProcessApi.getMaterialsByLotNo(
+          mashingData.lotNo
+        );
         console.log("✅ 불러온 자재 목록:", materialsList);
 
-          // ✅ "물" 데이터 찾기
-      const waterMaterial = materialsList.find((item) => item.materialName === "물");
-      const waterInputVolume = waterMaterial ? Number(waterMaterial.totalQty) : 0;
+        // ✅ "물" 데이터 찾기
+        const waterMaterial = materialsList.find(
+          (item) => item.materialName === "물"
+        );
+        const waterInputVolume = waterMaterial
+          ? Number(waterMaterial.totalQty)
+          : 0;
 
+        // ✅ 곡물 비율 계산 (숫자로 변환 후 합산)
+        const maltInputVolume = materialsList
+          .filter((item) =>
+            ["페일 몰트", "필스너 몰트", "초콜릿 몰트"].includes(
+              item.materialName
+            )
+          )
+          .reduce((sum, item) => sum + Number(item.totalQty), 0);
 
-         // ✅ 곡물 비율 계산 (숫자로 변환 후 합산)
-      const maltInputVolume = materialsList
-      .filter((item) => ["페일 몰트", "필스너 몰트", "초콜릿 몰트"].includes(item.materialName))
-      .reduce((sum, item) => sum + Number(item.totalQty), 0);
-
-    const mainMaterialInputVolume = materialsList
-      .filter((item) => ["보리", "밀", "쌀"].includes(item.materialName))
-      .reduce((sum, item) => sum + Number(item.totalQty), 0);
+        const mainMaterialInputVolume = materialsList
+          .filter((item) => ["보리", "밀", "쌀"].includes(item.materialName))
+          .reduce((sum, item) => sum + Number(item.totalQty), 0);
 
         const grainRatio = maltInputVolume + mainMaterialInputVolume;
         const waterRatio = waterInputVolume;
- 
+
         // ✅ 비율 계산: 곡물비율을 1로 맞추고, 물 비율을 반올림
-        const waterRatioAdjusted = grainRatio > 0 ? Math.round(waterRatio / grainRatio) : 0;
-        console.log(`📌 자동 계산된 비율 -> 곡물: 1, 물: ${waterRatioAdjusted}`);
- 
+        const waterRatioAdjusted =
+          grainRatio > 0 ? Math.round(waterRatio / grainRatio) : 0;
+        console.log(
+          `📌 자동 계산된 비율 -> 곡물: 1, 물: ${waterRatioAdjusted}`
+        );
 
         setMashingData((prev) => ({
           ...prev,
@@ -130,35 +140,64 @@ const MashingProcessControls = ({ workOrder }) => {
     fetchMaterialData();
   }, [mashingData.lotNo]);
 
-
-
-
-
-
   // 입력값 변경 핸들러
   const handleChange = (e) => {
     const { name, value } = e.target;
     setMashingData((prev) => ({ ...prev, [name]: value }));
   };
 
-  // 타이머 시작 함수
-  const startTimer = () => {
-    console.log("⏳ 타이머 시작됨, mashingTime:", mashingData.mashingTime);
+  // ✅ `등록하기` 버튼 클릭 시 데이터 저장
+  const handleSave = async () => {
+    if (!mashingData.lotNo) {
+      alert("⚠️ LOT_NO가 없습니다!");
+      return;
+    }
 
+    try {
+      const mashingRequestData = {
+        ...mashingData,
+        processStatus: "진행 중", // ✅ 상태 업데이트
+      };
+      console.log("📌 저장할 데이터:", mashingRequestData);
+
+      const response = await mashingProcessApi.saveMashingData(
+        mashingRequestData
+      );
+      console.log("📌 서버 응답:", response); // ✅ 응답 확인
+
+      
+    if (response?.result?.savedMashingProcess?.mashingId) {
+      console.log("📌 저장된 mashingId:", response.result.savedMashingProcess.mashingId);
+      setMashingId(response.result.savedMashingProcess.mashingId);
+    } else {
+      console.warn("⚠️ 서버 응답에 mashingId가 없습니다.");
+    }
+
+      setMashingData((prev) => ({ ...prev, processStatus: "진행 중" }));
+      setShowSuccessModal(true);
+      setButtonLabel("다음 공정 이동");
+    } catch (error) {
+      console.error("❌ 데이터 저장 실패:", error);
+      setShowErrorModal(true);
+    }
+  };
+
+  // ✅ 타이머 시작 (테스트 환경에서는 5초)
+  const startTimer = () => {
+    setIsProcessing(true);
     const totalTime =
       process.env.NODE_ENV === "development"
         ? 5
         : Number(mashingData.mashingTime) * 60;
     setTimer(totalTime);
-    setIsProcessing(true);
 
     const countdown = setInterval(() => {
-      setTimer((prevTime) => {
-        const newTime = prevTime - 1;
+      setTimer((prev) => {
+        const newTime = prev - 1;
         if (newTime <= 0) {
           clearInterval(countdown);
-          setShowCompleteModal(true);
           setIsProcessing(false);
+          setShowCompleteModal(true); // ✅ 완료 모달 표시
           setButtonLabel("다음 공정 이동");
           return 0;
         }
@@ -167,73 +206,41 @@ const MashingProcessControls = ({ workOrder }) => {
     }, 1000);
   };
 
-  // 데이터 저장 (등록하기 버튼 클릭 시)
-  const handleSave = async () => {
-    if (
-      !mashingData.temperature ||
-      !mashingData.grainRatio ||
-      !mashingData.waterRatio
-    ) {
-      alert("⚠️ 필수 입력값을 입력해주세요!");
+  // ✅ 다음 공정으로 이동 (phValue와 actualEndTime 저장)
+  const handleNextProcess = async () => {
+    if (!mashingData.phValue || isNaN(Number(mashingData.phValue))) {
+      console.error("❌ pH 값이 입력되지 않았거나 잘못된 값입니다.");
+      setShowErrorModal(true);
+      return;
+    }
+
+    if (!mashingId) {
+      console.error("❌ MashingID가 없습니다. API 요청을 중단합니다.");
+      setShowErrorModal(true);
       return;
     }
 
     try {
-      const mashingProcessPayload  = {
-        ...mashingData,
-        processStatus: "진행 중", // 공정 상태 변경
-        statusCode: "SC002", // 상태 코드 업데이트
-        processName: "당화", // 공정 이름 업데이트
+      const updatedMashingData = {
+        phValue: Number(mashingData.phValue),
+        actualEndTime: new Date().toISOString(),
       };
 
-      // 1️⃣ 당화공정 데이터 저장 (saveMashingData API 호출)
-      await mashingProcessApi.saveMashingData(mashingProcessPayload );
+      console.log("📌 업데이트할 데이터:", updatedMashingData);
 
-      // 2️⃣ processTracking 업데이트 (updateMashingProcess API 호출)
-      await mashingProcessApi.updateMashingProcess(mashingId, mashingProcessPayload );
-
-      setShowSuccessModal(true);
-      setButtonLabel("다음 공정 이동");
-      startTimer();
-    } catch (error) {
-      setShowErrorModal(true);
-    }
-  };
-
-
-
-
-
-  // 다음 공정으로 이동 (phValue와 actualEndTime 업데이트)
-  const handleNextProcess = async () => {
-    try {
-      const mashingUpdatePayload  = {
-        phValue: mashingData.phValue,
-        actualEndTime: new Date().toISOString(), // 현재 시간 저장
-      };
-
-      await mashingProcessApi.updateMashingProcess(mashingId, mashingUpdatePayload );
-
+      await mashingProcessApi.updateMashingProcess(
+        mashingId,
+        updatedMashingData
+      );
       navigate("/fermentation");
     } catch (error) {
       setShowErrorModal(true);
     }
   };
 
-
-
-
-  // 버튼 클릭 핸들러
-  const handleButtonClick = () => {
-    if (buttonLabel === "등록하기") {
-      handleSave();
-    } else if (buttonLabel === "다음 공정 이동") {
-      handleNextProcess();
-    }
-  };
-
-
-
+  useEffect(() => {
+    console.log("📌 현재 mashingId:", mashingId);
+  }, [mashingId]);
 
   return (
     <form
@@ -294,7 +301,7 @@ const MashingProcessControls = ({ workOrder }) => {
             type="number"
             name="grainRatio"
             value={mashingData.grainRatio}
-            readOnly 
+            readOnly
           />
           <label className={styles.mLabel051}>물 비율</label>
           <input
@@ -302,7 +309,7 @@ const MashingProcessControls = ({ workOrder }) => {
             type="number"
             name="waterRatio"
             value={mashingData.waterRatio}
-            readOnly 
+            readOnly
           />
         </div>
 
@@ -313,7 +320,7 @@ const MashingProcessControls = ({ workOrder }) => {
             type="number"
             name="waterInputVolume"
             value={mashingData.waterInputVolume}
-            readOnly 
+            readOnly
           />
         </div>
 
@@ -347,19 +354,26 @@ const MashingProcessControls = ({ workOrder }) => {
         <div className={styles.mGridItem}>
           <button
             className={styles.mSaveButton}
-            onClick={handleButtonClick}
-            disabled={buttonLabel === "등록하기" && timer > 0}
+            onClick={() => {
+              if (buttonLabel === "등록하기") {
+                setShowConfirmModal(true); // ✅ "등록하기"일 때만 선택 모달창 띄움
+              } else {
+                handleNextProcess(); // ✅ "다음 공정 이동"일 때는 바로 실행
+              }
+            }}
+            disabled={isProcessing}
           >
             {buttonLabel}
           </button>
         </div>
 
+        {/* ✅ "등록하기"일 때만 선택 모달창을 띄움 */}
         <ConfirmModal
           isOpen={showConfirmModal}
           message="등록하시겠습니까?"
           onConfirm={() => {
-            setShowConfirmModal(false);
-            setTimeout(handleSave, 100);
+            setShowConfirmModal(false); // ✅ 모달 먼저 닫기
+            setTimeout(handleSave, 100); // ✅ 100ms 후 실행 (비동기 실행 방지)
           }}
           onClose={() => setShowConfirmModal(false)}
         />
@@ -367,15 +381,21 @@ const MashingProcessControls = ({ workOrder }) => {
         <SuccessfulModal
           isOpen={showSuccessModal}
           message="데이터가 성공적으로 저장되었습니다!"
-          onClose={() => setShowSuccessModal(false)}
+          onClose={() => {
+            setShowSuccessModal(false);
+            startTimer(); // ✅ 타이머 시작
+          }}
         />
 
         <ErrorModal
           isOpen={showErrorModal}
-          message="데이터 저장에 실패했습니다. 다시 시도해주세요."
+          message={
+            mashingData.phValue
+              ? "데이터 저장에 실패했습니다. 다시 시도해주세요."
+              : "입력되지 않는 정보가 있습니다. 확인해주세요."
+          }
           onClose={() => setShowErrorModal(false)}
         />
-
         <CompleteModal
           isOpen={showCompleteModal}
           message={["당화 공정이 완료되었습니다.", "다음 공정으로 이동하세요."]}

--- a/src/components/production-process/material-grinding/MaterialGrindingControls.js
+++ b/src/components/production-process/material-grinding/MaterialGrindingControls.js
@@ -41,6 +41,9 @@ const MaterialGrindingControls = ({ grindingData, setGrindingData }) => {
     }
   }, [timer, timerStarted]); // 상태체크
 
+
+
+  
   const startTimer = () => {
     setTimerStarted(true); // ✅ 타이머 실행됨을 명확히 설정
     const totalTime =
@@ -52,6 +55,9 @@ const MaterialGrindingControls = ({ grindingData, setGrindingData }) => {
     // ✅ 부모 상태 업데이트
     setGrindingData((prev) => ({ ...prev, processStatus: "진행 중" }));
   };
+
+
+
 
   const handleSave = async () => {
     console.log("🔍 grindingData 전체 데이터:", grindingData);

--- a/src/pages/production-process/mashing-process/MashingProcessPage.js
+++ b/src/pages/production-process/mashing-process/MashingProcessPage.js
@@ -1,31 +1,42 @@
 import React, { useState, useEffect } from "react";
 import mashingProcessApi from "../../../apis/production-process/mashing-process/MashingProcessApi";
-import MashingProcessTable from "../../../components/production-process/mashing-process/MashingProcessTable";
 import MashingProcessControls from "../../../components/production-process/mashing-process/MashingProcessControls";
 
 const MashingProcessPage = () => {
     const [mashingDataList, setMashingDataList] = useState([]);
+    const [selectedWorkOrder, setSelectedWorkOrder] = useState({});
+
 
     useEffect(() => {
         // 당화공정 데이터 가져오기
         const fetchMashingData = async () => {
             try {
-                const response = await mashingProcessApi.getMashingData();
-                setMashingDataList(response.data);
+                const workOrders = await mashingProcessApi.getWorkOrderList();
+                setMashingDataList(workOrders);
+
+                if (workOrders.length > 0) {
+                    setSelectedWorkOrder(workOrders[0]); // 기본 작업지시를 첫 번째 값으로 설정
+                }
+
             } catch (error) {
                 console.error("❌ 당화공정 데이터 불러오기 실패:", error);
             }
         };
 
         fetchMashingData();
-    }, []);
+    }, []); 
 
     return (
         <div>            
-            <MashingProcessTable mashingDataList= {mashingDataList} setMashingDataList={setMashingDataList} />
-            <MashingProcessControls mashingDataList= {mashingDataList} setMashingDataList={setMashingDataList} />
+           <MashingProcessControls 
+                workOrder={selectedWorkOrder} // ✅ 작업지시 ID 전달
+                mashingDataList={mashingDataList} 
+                setMashingDataList={setMashingDataList} 
+            />
         </div>
     );
 };
 
 export default MashingProcessPage;
+
+


### PR DESCRIPTION


## #️⃣ Issue Number



## 📝 요약(Summary)
작업지시 ID  물 투입량 데이터 불러옴
분쇄공정(이전공정) 원재료+맥아 투입량의 합  곡물비율에 불러오기
물투입량  물 비율에 불러오기
분쇄공정(이전공장) 원재료+맥아 투입량의 합을  곡물비율에 1로 기준 설정
당화공정 물비율  곡물비율 대비 물투입량 값 입력(반올림설정함)
등록하기 클릭시 당화공정 엔티티 값 저장 및 공정추적상태 업데이트 구현
당화공정 완료후 pH값 및 실제 종료시간 다음공정이동 버튼 클릭시 업데이트 구현 및 다음공정(여과공정)이동 구현

# 🖼 프론트엔드 PR 유형

## 🧐 기능 및 UI  
- [x] 새로운 기능 추가  
- [ ] 스타일 및 UI 디자인 변경  
- [x] React 컴포넌트 리팩토링 (`컴포넌트` 분리, `Props` 구조 변경, 재사용성 개선)
- [ ] 라우팅 관련 수정 (`React Router` 추가/삭제, 네비게이션 로직 변경)

## 😎 상태 및 성능    
- [ ] React 상태 관리 관련 변경 (`Redux`, `Context API`)  
- [x] React 훅 관련 수정 (`useEffect` 최적화, 의존성 배열 수정)  
- [ ] React 성능 최적화 (`useReducer`, `useMemo`, `useCallback` 활용)
- [x] API 연동 및 데이터 페칭 수정 (`Axios`, `Fetch`, `Async`)

## 😈 버그  
- [ ] 버그 수정

## 😘 기타  
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [x] 불필요한 코드 및 파일 삭제
- [x] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)
공정추적 상태 변동 완료
![스크린샷 2025-03-07 123859](https://github.com/user-attachments/assets/9e69ec5a-ead5-45f3-819b-16a4930a8125)
당화공정 등록 성공후 ph값 업데이트 등록 완료 ( 당화공정 등록 사진생략 믿음!)
<img width="505" alt="스크린샷 2025-03-07 124240" src="https://github.com/user-attachments/assets/22b4c9d2-b785-49b3-9c7d-77fb060a8450" />
이쁘지 않지만 나름 많은게 들어간 프론트 사진 2장
![스크린샷 2025-03-07 124122](https://github.com/user-attachments/assets/3cd3324d-0383-404c-9ece-a66082a9aba1)
![스크린샷 2025-03-07 124144](https://github.com/user-attachments/assets/b63ae839-335e-4e0f-8279-2281d31e5e0a)

## ✅ PR Checklist
📢 문정현 형상관리자님 MERGE 잘부탁드려요
- [ ] 이승현(PM)
- [ ] 문정현(형상관리자)
- [x] 김남규(DB)
- [ ] 김관훈(DB)
